### PR TITLE
Add Router ID with environment KEEPALIVED_ROUTER_ID

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 NAME = osixia/keepalived
-VERSION = 1.4.2
+VERSION = 1.4.3
 
 .PHONY: build build-nocache test tag-latest push push-latest release git-tag-version
 

--- a/image/environment/default.yaml
+++ b/image/environment/default.yaml
@@ -16,3 +16,5 @@ KEEPALIVED_VIRTUAL_IPS:
   - 192.168.1.232
 
 KEEPALIVED_NOTIFY: /container/service/keepalived/assets/notify.sh
+
+KEEPALIVED_ROUTER_ID: 51

--- a/image/service/keepalived/assets/keepalived.conf
+++ b/image/service/keepalived/assets/keepalived.conf
@@ -10,7 +10,7 @@ vrrp_instance VI_1 {
   }
 
   state BACKUP
-  virtual_router_id 51
+  virtual_router_id {{ KEEPALIVED_ROUTER_ID }}
   priority {{ KEEPALIVED_PRIORITY }}
   nopreempt
 

--- a/image/service/keepalived/startup.sh
+++ b/image/service/keepalived/startup.sh
@@ -11,6 +11,7 @@ if [ ! -e "$FIRST_START_DONE" ]; then
   #
   # bootstrap config
   #
+  sed -i "s|{{ KEEPALIVED_ROUTER_ID }}|$KEEPALIVED_ROUTER_ID|g" ${CONTAINER_SERVICE_DIR}/keepalived/assets/keepalived.conf
   sed -i "s|{{ KEEPALIVED_INTERFACE }}|$KEEPALIVED_INTERFACE|g" ${CONTAINER_SERVICE_DIR}/keepalived/assets/keepalived.conf
   sed -i "s|{{ KEEPALIVED_PRIORITY }}|$KEEPALIVED_PRIORITY|g" ${CONTAINER_SERVICE_DIR}/keepalived/assets/keepalived.conf
   sed -i "s|{{ KEEPALIVED_PASSWORD }}|$KEEPALIVED_PASSWORD|g" ${CONTAINER_SERVICE_DIR}/keepalived/assets/keepalived.conf


### PR DESCRIPTION
in some case you have another keepalived on a same server. so, it will be conflict with default router id(51). I add KEEPALIVED_ROUTER_ID to change this number.
