### PR TITLE
Update process.sh

### DIFF
--- a/image/service/keepalived/process.sh
+++ b/image/service/keepalived/process.sh
@@ -12,4 +12,5 @@ do
 done
 echo "ok"
 
+rm -f /var/run/keepalived.pid
 exec /usr/local/sbin/keepalived -f /usr/local/etc/keepalived/keepalived.conf --dont-fork --log-console ${KEEPALIVED_COMMAND_LINE_ARGUMENTS}


### PR DESCRIPTION
fixed #18 when "docker kill keepalived",  file "/var/run/keepalived.pid" still existed, so the container cannot start.