### PR TITLE
Update keepalived to 2.1.5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 NAME = osixia/keepalived
-VERSION = 2.0.20
+VERSION = 2.1.5
 
 .PHONY: build build-nocache test tag-latest push push-latest release git-tag-version
 

--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -3,7 +3,7 @@
 FROM osixia/light-baseimage:alpine-0.1.6-dev
 
 # Keepalived version
-ARG KEEPALIVED_VERSION=2.0.20
+ARG KEEPALIVED_VERSION=2.1.5
 
 # Download, build and install Keepalived
 RUN apk --no-cache add \


### PR DESCRIPTION
Hi, I'm just updating keepalived for now and didn't adjust all other locations as I might do a few more commits that could fit into the next release.
I tested 2.1.5 in a simple setup with 3 vms and it worked as expected for me.

If you could create a release branch for this version I can adjust my PR.

Thanks, Vincent